### PR TITLE
Aligned package name with the repository name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "roon-extension-devialet-phantom-upnp",
+  "name": "roon-extension-devialet-phantom-volume",
   "version": "1.0.0",
-  "description": "Roon Extension to let Roon control the Devialet Phantom Premier devices via UPnP",
+  "description": "Roon Extension to let Roon control the Devialet Phantom Premier's volume via UPnP",
   "main": "app.js",
   "author": "Roon Labs, LLC",
   "license": "Apache-2.0",


### PR DESCRIPTION
Hi @dannydulai,

The naming of the new Devialet Phantom extension is inconsistent, the repository is named `roon-extension-devialet-phantom-volume` while the package is named `roon-extension-devialet-phantom-upnp`. This difference makes that the extension currently cannot be installed via the Extension Manager. This can of course be fixed, but I think that it makes sense to have consistent naming.

From a functional perspective I also think that mentioning volume is better than mentioning UPnP, as the first describes the actual function while the second describes the implementation (for a lack of something better).